### PR TITLE
[docs] community discussions change

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Contributors are required to abide by our [Code of Conduct](https://github.com/o
 
 ## License
 
-[Apache-2.0](LICENSE) © 2019 OpenThread Authors <openthread-users@googlegroups.com>
+[Apache-2.0](LICENSE) © 2019 OpenThread Authors https://github.com/openthread/openthread/discussions

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Contributors are required to abide by our [Code of Conduct](https://github.com/o
 
 ## License
 
-[Apache-2.0](LICENSE) © 2019 OpenThread Authors https://github.com/openthread/openthread/discussions
+[Apache-2.0](LICENSE) © 2019 OpenThread Authors

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "size-report",
   "version": "0.1.0",
   "description": "Generate size report for pull request",
-  "author": "OpenThread Authors https://github.com/openthread/openthread/discussions",
+  "author": "OpenThread Authors https://github.com/openthread/openthread",
   "license": "Apache-2.0",
   "repository": "https://github.com/openthread/size-report.git",
   "homepage": "https://github.com/openthread/size-report",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "size-report",
   "version": "0.1.0",
   "description": "Generate size report for pull request",
-  "author": "OpenThread Authors https://github.com/openthread/openthread",
+  "author": "OpenThread Authors (https://github.com/openthread/openthread)",
   "license": "Apache-2.0",
   "repository": "https://github.com/openthread/size-report.git",
   "homepage": "https://github.com/openthread/size-report",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "size-report",
   "version": "0.1.0",
   "description": "Generate size report for pull request",
-  "author": "OpenThread Authors <openthread-users@googlegroups.com>",
+  "author": "OpenThread Authors https://github.com/openthread/openthread/discussions",
   "license": "Apache-2.0",
   "repository": "https://github.com/openthread/size-report.git",
   "homepage": "https://github.com/openthread/size-report",


### PR DESCRIPTION
Replace link to openthread-users Google Group with link to GitHub OpenThread Discussions, clarify issue reporting links.